### PR TITLE
Prevent ocaml_gstreamer_loop_quit from freezing during shutdown

### DIFF
--- a/src/gstreamer_stubs.c
+++ b/src/gstreamer_stubs.c
@@ -586,18 +586,30 @@ CAMLprim value ocaml_gstreamer_loop_run(value l)
 
   caml_release_runtime_system();
   g_main_loop_run(loop);
+  g_main_loop_unref(loop);
   caml_acquire_runtime_system();
 
   CAMLreturn(Val_unit);
+}
+
+gboolean gstreamer_loop_quit_helper(gpointer user_data)
+{
+  GMainLoop* loop = user_data;
+  g_main_loop_quit(loop);
+  return FALSE;
 }
 
 CAMLprim value ocaml_gstreamer_loop_quit(value l)
 {
   CAMLparam1(l);
   GMainLoop* loop = Loop_val(l);
+  GSource* idle_source;
   
   caml_release_runtime_system();
-  g_main_loop_quit(loop);
+  idle_source=g_idle_source_new();
+  g_source_set_callback(idle_source, gstreamer_loop_quit_helper, loop, NULL);
+  g_source_attach(idle_source, NULL);
+  g_source_unref(idle_source);
   caml_acquire_runtime_system();
 
   CAMLreturn(Val_unit);


### PR DESCRIPTION
Currently, it calls `g_main_loop_quit(loop)` directly.
Thus, `g_main_loop_quit` can be called before `g_main_loop_run` is called if liquidsoap tries to exit immediately after it is started because thread execution order is undetermined.

If `g_main_loop_quit` can be called before `g_main_loop_run` is called, ocaml-gstreamer can freeze.

I fixed the issue by making it call `g_main_loop_quit` in the loop.
If it is called in the loop, there is no freezing during shutdown.